### PR TITLE
chore: Add runnable example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,7 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "genco",
+ "wit-bindgen",
  "wit-bindgen-core",
  "wit-component",
 ]
@@ -226,6 +227,16 @@ name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -464,6 +475,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c966692b6d8c4bb3c1aee3313e0930f44457a5763cfffb666f814506124e4691"
+dependencies = [
+ "wit-bindgen-rt",
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
 name = "wit-bindgen-core"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +493,46 @@ dependencies = [
  "anyhow",
  "heck",
  "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d5562e971a823cf5a550a9d69cb7144e9b4969a810043127175517a4e1865"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d894e599c161d71acb6a78e8ec8a609a09c2bb227de50829f5afbd03b844a69"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a723cf943bba3bf34f437eb101e5a78180971e25dfb0085d80dbe4e73afb2854"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,15 @@ Gravity is a host generator for WebAssembly Components. It currently targets Waz
 name = "gravity"
 path = "src/main.rs"
 
+[[example]]
+name = "examples"
+crate-type = ["cdylib"]
+
 [dependencies]
 clap = "=4.5.30"
 genco = "=0.17.10"
 wit-bindgen-core = "=0.35.0"
 wit-component = "=0.220.0"
+
+[dev-dependencies]
+wit-bindgen = "=0.35.0"

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ dependencies. You can run:
 go mod tidy
 ```
 
+## Example
+
+An runnable example in our [examples/](./examples/) directory. Please see the
+[README](./examples/README.md) for instructions on running it.
+
 ## Status
 
 

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,2 @@
+examples.go
+examples.wasm

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,37 @@
+# Example
+
+This example is provided as a guide for using a `wit-bindgen` guest written in
+Rust with Gravity.
+
+## 1. Add the WebAssembly target
+
+Gravity doesn't use WebAssembly itself, so you'll want to add the
+`wasm32-unknown-unknown` target to your toolchain.
+
+```sh
+rustup target add wasm32-unknown-unknown
+```
+
+## 2. Build the example to Core Wasm
+
+Gravity currently needs a "Core Wasm" file with an embedded WIT custom section.
+This can be built via [Cargo Examples][cargo-examples]
+
+```sh
+cargo build --example examples --target wasm32-unknown-unknown
+```
+
+## 3. Run Gravity against the Core Wasm file
+
+Gravity can be run against the Wasm file produced in Rust's `target/` directory.
+
+```sh
+cargo run target/wasm32-unknown-unknown/debug/examples/examples.wasm  -o examples/examples.go --world examples
+```
+
+## 4. Use the generate Go & Wasm files
+
+The above command will produce a `examples.go` and `examples.wasm` file inside
+the `examples/` directory. These could be used within a Go project.
+
+[cargo-examples]: https://doc.rust-lang.org/cargo/reference/cargo-targets.html#examples

--- a/examples/examples.rs
+++ b/examples/examples.rs
@@ -1,0 +1,18 @@
+use arcjet::examples::logger;
+
+wit_bindgen::generate!({
+    world: "examples",
+    path: "./examples"
+});
+
+struct ExampleWorld;
+
+export!(ExampleWorld);
+
+impl Guest for ExampleWorld {
+    fn foobar() -> Result<String, String> {
+        logger::debug("DEBUG MESSAGE");
+
+        Ok("Baz".into())
+    }
+}

--- a/examples/examples.wit
+++ b/examples/examples.wit
@@ -1,0 +1,14 @@
+package arcjet:examples;
+
+interface logger {
+  debug: func(msg: string);
+  log: func(msg: string);
+  warn: func(msg: string);
+  error: func(msg: string);
+}
+
+world examples {
+  import logger;
+
+  export foobar: func() -> result<string, string>;
+}


### PR DESCRIPTION
Closes #27 

This adds a runnable example that explains how to compile a Rust file into a Core Wasm module and run Gravity against it.

cc @scothis