### PR TITLE
fix(cmd/gravity): forbid building on non-nightly compilers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,7 @@ version = "0.0.2"
 dependencies = [
  "clap",
  "genco",
+ "rustversion",
  "wit-bindgen",
  "wit-bindgen-core",
  "wit-component",
@@ -358,6 +359,12 @@ name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"

--- a/cmd/gravity/Cargo.toml
+++ b/cmd/gravity/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/arcjet/gravity"
 description = """
 Gravity is a host generator for WebAssembly Components. It currently targets Wazero, a zero dependency WebAssembly runtime for Go.
 """
+build = "build.rs"
 
 [[bin]]
 name = "gravity"
@@ -23,3 +24,6 @@ wit-component = "=0.230.0"
 
 [dev-dependencies]
 wit-bindgen = "=0.42.1"
+
+[build-dependencies]
+rustversion = "=1.0.20"

--- a/cmd/gravity/build.rs
+++ b/cmd/gravity/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    assert!(
+        rustversion::cfg!(nightly),
+        "Gravity must be compiled with the nightly release of Rust"
+    );
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -9,5 +9,8 @@ components = [
     "clippy",
     "rust-src",
 ]
-targets = ["wasm32-unknown-unknown"]
+targets = [
+    "wasm32-unknown-unknown",
+    "wasm32-wasip1",
+]
 profile = "default"


### PR DESCRIPTION
This is a cherry-pick of https://github.com/arcjet/gravity/pull/56/commits/1a9df809b00c75156fa8656532c33f9c00ce2329 but I've switched to `rustversion` which was named as an alternative in the readme. I mainly did this because I didn't recognize the maintainer of `rustc_version` and this is a rare case where I'd rather use a macro because then we don't need to call `.unwrap()`.

Builds upon #60 