### PR TITLE
ci: Update harden-runner allowed-endpoints 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent:443
             github.com:443
             index.crates.io:443
             static.crates.io:443


### PR DESCRIPTION
Github changed their domain aliasing, and so it's time to add another
domain to the list.
