### PR TITLE
fix: don't call cabi_post_* for primitives

### DIFF
--- a/cmd/gravity/src/main.rs
+++ b/cmd/gravity/src/main.rs
@@ -128,7 +128,11 @@ impl GoType {
             GoType::String | GoType::Slice(_) => true,
 
             // Complex types need cleanup if their inner types do
-            GoType::ValueOrOk(inner) | GoType::ValueOrError(inner) => inner.needs_cleanup(),
+            GoType::ValueOrOk(inner) => inner.needs_cleanup(),
+
+            // The inner type of `Err` is always a String so it requires cleanup
+            // TODO(#91): Store the error type to check both inner types.
+            GoType::ValueOrError(_) => true,
 
             // Interfaces (variants) might need cleanup (conservative approach)
             GoType::Interface => true,

--- a/cmd/gravity/src/main.rs
+++ b/cmd/gravity/src/main.rs
@@ -146,7 +146,7 @@ impl GoType {
             // - Records containing only primitives
             // - Type aliases to primitives
             //
-            // TODO(#cleanup): Improve this by either:
+            // TODO(#92): Improve this by either:
             // 1. Passing the Resolve context to check actual type definitions
             // 2. Tracking cleanup requirements during type resolution
             // 3. Using a different representation that carries this information

--- a/cmd/gravity/src/main.rs
+++ b/cmd/gravity/src/main.rs
@@ -89,6 +89,74 @@ enum GoType {
     Nothing,
 }
 
+impl GoType {
+    /// Returns true if this type needs post-return cleanup (cabi_post_* function)
+    ///
+    /// According to the Component Model Canonical ABI specification, cleanup is needed
+    /// for types that allocate memory in the guest's linear memory when being returned.
+    ///
+    /// Types that need cleanup:
+    /// - Strings: allocate memory for the string data
+    /// - Lists/Slices: allocate memory for the array data
+    /// - Types containing the above (recursively)
+    ///
+    /// Types that DON'T need cleanup:
+    /// - Primitives (bool, integers, floats): passed by value
+    /// - Enums: represented as integers
+    ///
+    /// Limitations:
+    /// - For UserDefined types (records, type aliases), we can't determine here if they
+    ///   contain strings/lists without the full type definition, so we're conservative
+    /// - A perfect implementation would recursively check record fields, but that would
+    ///   require passing the Resolve context here
+    fn needs_cleanup(&self) -> bool {
+        match self {
+            // Primitive types don't need cleanup
+            GoType::Bool
+            | GoType::Uint8
+            | GoType::Uint16
+            | GoType::Uint32
+            | GoType::Uint64
+            | GoType::Int8
+            | GoType::Int16
+            | GoType::Int32
+            | GoType::Int64
+            | GoType::Float32
+            | GoType::Float64 => false,
+
+            // String and slices allocate memory and need cleanup
+            GoType::String | GoType::Slice(_) => true,
+
+            // Complex types need cleanup if their inner types do
+            GoType::ValueOrOk(inner) | GoType::ValueOrError(inner) => inner.needs_cleanup(),
+
+            // Interfaces (variants) might need cleanup (conservative approach)
+            GoType::Interface => true,
+
+            // User-defined types (records, enums, type aliases) need cleanup if they
+            // contain strings or other allocated types. Since we don't have access to
+            // the type definition here, we must be conservative and assume they might.
+            //
+            // This means we might generate unnecessary cleanup calls for:
+            // - Enums (which are just integers)
+            // - Records containing only primitives
+            // - Type aliases to primitives
+            //
+            // TODO(#cleanup): Improve this by either:
+            // 1. Passing the Resolve context to check actual type definitions
+            // 2. Tracking cleanup requirements during type resolution
+            // 3. Using a different representation that carries this information
+            GoType::UserDefined(_) => true,
+
+            // Error is actually Result<None, String> - strings need cleanup!
+            GoType::Error => true,
+
+            // Nothing represents no value, so no cleanup needed
+            GoType::Nothing => false,
+        }
+    }
+}
+
 impl FormatInto<Go> for &GoType {
     fn format_into(self, tokens: &mut Tokens<Go>) {
         match self {
@@ -148,6 +216,16 @@ impl FormatInto<Go> for GoType {
 enum GoResult {
     Empty,
     Anon(GoType),
+}
+
+impl GoResult {
+    /// Returns true if this result type needs post-return cleanup
+    fn needs_cleanup(&self) -> bool {
+        match self {
+            GoResult::Empty => false,
+            GoResult::Anon(typ) => typ.needs_cleanup(),
+        }
+    }
 }
 
 impl FormatInto<Go> for GoResult {
@@ -438,22 +516,23 @@ impl Bindgen for Func {
                         }
                     })
 
-
-                    $(comment(&[
-                        "The cleanup via `cabi_post_*` cleans up the memory in the guest. By",
-                        "deferring this, we ensure that no memory is corrupted before the function",
-                        "is done accessing it."
-                    ]))
-                    defer func() {
-                        if _, err := i.module.ExportedFunction($(quoted(format!("cabi_post_{name}")))).Call(ctx, $raw...); err != nil {
-                            $(comment(&[
-                                "If we get an error during cleanup, something really bad is",
-                                "going on, so we panic. Also, you can't return the error from",
-                                "the `defer`"
-                            ]))
-                            panic($errors_new("failed to cleanup"))
-                        }
-                    }()
+                    $(if self.result.needs_cleanup() {
+                        $(comment(&[
+                            "The cleanup via `cabi_post_*` cleans up the memory in the guest. By",
+                            "deferring this, we ensure that no memory is corrupted before the function",
+                            "is done accessing it."
+                        ]))
+                        defer func() {
+                            if _, err := i.module.ExportedFunction($(quoted(format!("cabi_post_{name}")))).Call(ctx, $raw...); err != nil {
+                                $(comment(&[
+                                    "If we get an error during cleanup, something really bad is",
+                                    "going on, so we panic. Also, you can't return the error from",
+                                    "the `defer`"
+                                ]))
+                                panic($errors_new("failed to cleanup"))
+                            }
+                        }()
+                    })
 
                     $ret := $raw[0]
                 };

--- a/examples/basic/basic_test.go
+++ b/examples/basic/basic_test.go
@@ -36,3 +36,72 @@ func TestBasic(t *testing.T) {
 		t.Errorf("wanted: %s, but got: %s", want, message)
 	}
 }
+
+func TestNoPrimitiveCleanup(t *testing.T) {
+	fac, err := NewBasicFactory(t.Context(), SlogLogger{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fac.Close(t.Context())
+
+	ins, err := fac.Instantiate(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ins.Close(t.Context())
+
+	actual := ins.Primitive(t.Context())
+
+	const expected = true
+	if actual != expected {
+		t.Errorf("expected: %t, but got: %t", expected, actual)
+	}
+}
+
+func TestNoOptionalPrimitiveCleanup(t *testing.T) {
+	fac, err := NewBasicFactory(t.Context(), SlogLogger{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fac.Close(t.Context())
+
+	ins, err := fac.Instantiate(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ins.Close(t.Context())
+
+	actual, ok := ins.OptionalPrimitive(t.Context())
+	if !ok {
+		t.Fatal(err)
+	}
+
+	const expected = true
+	if actual != expected {
+		t.Errorf("expected: %t, but got: %t", expected, actual)
+	}
+}
+
+func TestResultPrimitiveCleanup(t *testing.T) {
+	fac, err := NewBasicFactory(t.Context(), SlogLogger{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fac.Close(t.Context())
+
+	ins, err := fac.Instantiate(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ins.Close(t.Context())
+
+	actual, err := ins.ResultPrimitive(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const expected = true
+	if actual != expected {
+		t.Errorf("expected: %t, but got: %t", expected, actual)
+	}
+}

--- a/examples/basic/src/lib.rs
+++ b/examples/basic/src/lib.rs
@@ -14,4 +14,13 @@ impl Guest for BasicWorld {
 
         Ok("Hello, world!".into())
     }
+    fn primitive() -> bool {
+        true
+    }
+    fn optional_primitive() -> Option<bool> {
+        Some(true)
+    }
+    fn result_primitive() -> Result<bool, String> {
+        Ok(true)
+    }
 }

--- a/examples/basic/wit/basic.wit
+++ b/examples/basic/wit/basic.wit
@@ -11,4 +11,7 @@ world basic {
   import logger;
 
   export hello: func() -> result<string, string>;
+  export primitive: func() -> bool;
+  export optional-primitive: func() -> option<bool>;
+  export result-primitive: func() -> result<bool, string>;
 }


### PR DESCRIPTION
Primitives don't allocate memory, so we don't need to call the cleanup function. This was breaking instances where the return type was a u32, since they would try to reference a memory location that wasn't allocated.

The `needs_cleanup` method is somewhat incomplete because it doesn't handle user-defined types yet, but that's inline with the rest of the codebase for now.

For transparency, this was done with some help from Claude, so I did actually generate a bit of a test harness, but don't want to bombard the repo with too much opinionated code!