### PR TITLE
feat: support stable Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,6 @@ version = "0.0.2"
 dependencies = [
  "clap",
  "genco",
- "rustversion",
  "wit-bindgen",
  "wit-bindgen-core",
  "wit-component",
@@ -234,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "genco"
-version = "0.17.10"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35958104272e516c2a5f66a9d82fba4784d2b585fc1e2358b8f96e15d342995"
+checksum = "1926a45e14479803957ec6afd3c908c4c3e5932f47498f9f05b86eb163da5ebf"
 dependencies = [
  "genco-macros",
  "relative-path",
@@ -245,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "genco-macros"
-version = "0.17.10"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43eaff6bbc0b3a878361aced5ec6a2818ee7c541c5b33b5880dfa9a86c23e9e7"
+checksum = "9b10835e55170d94267857173f287655e3dea033e0f6f7622c0482d1d50eb684"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -367,12 +366,6 @@ name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"

--- a/README.md
+++ b/README.md
@@ -40,20 +40,20 @@ To produce Go files with good indentation, this tool should be installed with a
 Rust toolchain at least as recent as 1.88.0. For example:
 
 ```bash
-rustup toolchain install 1.90.0
+rustup toolchain install stable
 ```
 
 From inside this directory, you can install using the command:
 
 ```bash
-cargo +1.90.0 install --path cmd/gravity
+cargo install --path cmd/gravity
 ```
 
 Or alternatively, you can install the latest published version from crates.io
 using this command:
 
 ```bash
-cargo +1.90.0 install arcjet-gravity
+cargo install arcjet-gravity
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -37,23 +37,23 @@ ABI][canonical-abi].
 ## Installation
 
 To produce Go files with good indentation, this tool should be installed with a
-Rust nightly toolchain. You can install one with:
+Rust toolchain at least as recent as 1.88.0. For example:
 
 ```bash
-rustup toolchain install nightly-2025-01-01
+rustup toolchain install 1.90.0
 ```
 
 From inside this directory, you can install using the command:
 
 ```bash
-cargo +nightly-2025-01-01 install --path cmd/gravity
+cargo +1.90.0 install --path cmd/gravity
 ```
 
 Or alternatively, you can install the latest published version from crates.io
 using this command:
 
 ```bash
-cargo +nightly-2025-01-01 install arcjet-gravity
+cargo +1.90.0 install arcjet-gravity
 ```
 
 ## Usage

--- a/cmd/gravity/Cargo.toml
+++ b/cmd/gravity/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/arcjet/gravity"
 description = """
 Gravity is a host generator for WebAssembly Components. It currently targets Wazero, a zero dependency WebAssembly runtime for Go.
 """
+rust-version = "1.88"
 
 [[bin]]
 name = "gravity"

--- a/cmd/gravity/Cargo.toml
+++ b/cmd/gravity/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/arcjet/gravity"
 description = """
 Gravity is a host generator for WebAssembly Components. It currently targets Wazero, a zero dependency WebAssembly runtime for Go.
 """
-build = "build.rs"
 
 [[bin]]
 name = "gravity"
@@ -18,12 +17,9 @@ path = "src/main.rs"
 
 [dependencies]
 clap = "=4.5.47"
-genco = "=0.17.10"
+genco = "0.18"
 wit-bindgen-core = "=0.42.1"
 wit-component = "=0.230.0"
 
 [dev-dependencies]
 wit-bindgen = "=0.42.1"
-
-[build-dependencies]
-rustversion = "=1.0.22"

--- a/cmd/gravity/Cargo.toml
+++ b/cmd/gravity/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = "=4.5.47"
-genco = "0.18"
+genco = "=0.18.1"
 wit-bindgen-core = "=0.42.1"
 wit-component = "=0.230.0"
 

--- a/cmd/gravity/build.rs
+++ b/cmd/gravity/build.rs
@@ -1,6 +1,0 @@
-fn main() {
-    assert!(
-        rustversion::cfg!(nightly),
-        "Gravity must be compiled with the nightly release of Rust"
-    );
-}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-01-01"
+channel = "1.90.0"
 components = [
     "rustc",
     "cargo",


### PR DESCRIPTION
Prior to this commit, this project required nightly Rust.
This was because it used genco 0.17, which didn't generate
code with the correct indentation. However, since Rust 1.88 and
genco 0.18, this can be done on stable Rust.

This commit switches the rust-toolchain.toml to a stable toolchain,
removes the build script, and updates the README to use stable instead.

See https://docs.rs/genco/latest/genco/ which mentions the support for stable >= 1.88.0!
