### PR TITLE
refactor: move Bindings struct to lib; begin refactoring codegen

### DIFF
--- a/cmd/gravity/src/codegen/bindings.rs
+++ b/cmd/gravity/src/codegen/bindings.rs
@@ -1,0 +1,128 @@
+use genco::{prelude::*, tokens::Tokens};
+use wit_bindgen_core::wit_parser::{Record, Resolve, Type, TypeDef, TypeDefKind};
+
+use crate::{
+    codegen::wasm::{Wasm, WasmData},
+    go::*,
+    resolve_type,
+};
+
+/// The WIT bindings for a world.
+pub struct Bindings {
+    /// The cumulative output tokens containing the Go bindings.
+    // TODO(#16): Don't use the internal bindings.out field
+    pub out: Tokens<Go>,
+
+    /// The identifier of the Go variable containing the WebAssembly bytes.
+    raw_wasm_var: GoIdentifier,
+}
+
+impl Bindings {
+    /// Creates a new bindings generator for the selected world.
+    pub fn new(world: &str) -> Self {
+        let wasm_var = GoIdentifier::private(format!("wasm-file-{world}"));
+        Self {
+            // world,
+            out: Tokens::new(),
+            raw_wasm_var: wasm_var,
+        }
+    }
+
+    /// Adds the given Wasm to the bindings.
+    pub fn include_wasm(&mut self, wasm: WasmData) {
+        Wasm::new(&self.raw_wasm_var, wasm).format_into(&mut self.out)
+    }
+
+    pub fn define_type(&mut self, typ_def: &TypeDef, resolve: &Resolve) {
+        let TypeDef { name, kind, .. } = typ_def;
+        match kind {
+            TypeDefKind::Record(Record { fields }) => {
+                let name = GoIdentifier::public(name.as_deref().expect("record to have a name"));
+                let fields = fields.iter().map(|field| {
+                    (
+                        GoIdentifier::public(&field.name),
+                        resolve_type(&field.ty, resolve),
+                    )
+                });
+
+                quote_in! { self.out =>
+                    $['\n']
+                    type $name struct {
+                        $(for (name, typ) in fields join ($['\r']) => $name $typ)
+                    }
+                }
+            }
+            TypeDefKind::Resource => todo!("TODO(#5): implement resources"),
+            TypeDefKind::Handle(_) => todo!("TODO(#5): implement resources"),
+            TypeDefKind::Flags(_) => todo!("TODO(#4):generate flags type definition"),
+            TypeDefKind::Tuple(_) => todo!("TODO(#4):generate tuple type definition"),
+            TypeDefKind::Variant(_) => {
+                // TODO(#4): Generate aliases if the variant name doesn't match the struct name
+            }
+            TypeDefKind::Enum(inner) => {
+                let name = name.clone().expect("enum to have a name");
+                let enum_type = &GoIdentifier::private(&name);
+
+                let enum_interface = GoIdentifier::public(&name);
+
+                let enum_function = &GoIdentifier::private(format!("is-{}", &name));
+
+                let variants = inner
+                    .cases
+                    .iter()
+                    .map(|variant| GoIdentifier::public(&variant.name));
+
+                quote_in! { self.out =>
+                    $['\n']
+                    type $enum_interface interface {
+                        $enum_function()
+                    }
+
+                    type $enum_type int
+
+                    func ($enum_type) $enum_function() {}
+
+                    const (
+                        $(for name in variants join ($['\r']) => $name $enum_type = iota)
+                    )
+                }
+            }
+            TypeDefKind::Option(_) => todo!("TODO(#4): generate option type definition"),
+            TypeDefKind::Result(_) => todo!("TODO(#4): generate result type definition"),
+            TypeDefKind::List(_) => todo!("TODO(#4): generate list type definition"),
+            TypeDefKind::Future(_) => todo!("TODO(#4): generate future type definition"),
+            TypeDefKind::Stream(_) => todo!("TODO(#4): generate stream type definition"),
+            TypeDefKind::Type(Type::Id(_)) => {
+                // TODO(#4):  Only skip this if we have already generated the type
+            }
+            TypeDefKind::Type(Type::Bool) => todo!("TODO(#4): generate bool type alias"),
+            TypeDefKind::Type(Type::U8) => todo!("TODO(#4): generate u8 type alias"),
+            TypeDefKind::Type(Type::U16) => todo!("TODO(#4): generate u16 type alias"),
+            TypeDefKind::Type(Type::U32) => todo!("TODO(#4): generate u32 type alias"),
+            TypeDefKind::Type(Type::U64) => todo!("TODO(#4): generate u64 type alias"),
+            TypeDefKind::Type(Type::S8) => todo!("TODO(#4): generate s8 type alias"),
+            TypeDefKind::Type(Type::S16) => todo!("TODO(#4): generate s16 type alias"),
+            TypeDefKind::Type(Type::S32) => todo!("TODO(#4): generate s32 type alias"),
+            TypeDefKind::Type(Type::S64) => todo!("TODO(#4): generate s64 type alias"),
+            TypeDefKind::Type(Type::F32) => todo!("TODO(#4): generate f32 type alias"),
+            TypeDefKind::Type(Type::F64) => todo!("TODO(#4): generate f64 type alias"),
+            TypeDefKind::Type(Type::Char) => todo!("TODO(#4): generate char type alias"),
+            TypeDefKind::Type(Type::String) => {
+                let name =
+                    GoIdentifier::public(name.as_deref().expect("string alias to have a name"));
+                // TODO(#4): We might want a Type Definition (newtype) instead of Type Alias here
+                quote_in! { self.out =>
+                    $['\n']
+                    type $name = string
+                }
+            }
+            TypeDefKind::Type(Type::ErrorContext) => {
+                todo!("TODO(#4): generate error context definition")
+            }
+            TypeDefKind::FixedSizeList(_, _) => {
+                todo!("TODO(#4): generate fixed size list definition")
+            }
+            TypeDefKind::Unknown => panic!("cannot generate Unknown type"),
+        }
+    }
+}

--- a/cmd/gravity/src/codegen/mod.rs
+++ b/cmd/gravity/src/codegen/mod.rs
@@ -1,0 +1,5 @@
+mod bindings;
+mod wasm;
+
+pub use bindings::*;
+pub use wasm::WasmData;

--- a/cmd/gravity/src/codegen/wasm.rs
+++ b/cmd/gravity/src/codegen/wasm.rs
@@ -1,0 +1,91 @@
+use genco::prelude::*;
+
+use crate::go::{GoIdentifier, embed};
+
+/// The WebAssembly data for a world, either inline or embedded using go:embed.
+pub enum WasmData<'a> {
+    /// The WebAssembly file is inlined as a byte array.
+    Inline(&'a [u8]),
+    /// The WebAssembly file is embedded using go:embed.
+    Embedded(&'a str),
+}
+
+pub(crate) struct Wasm<'a> {
+    var: &'a GoIdentifier,
+    data: WasmData<'a>,
+}
+
+impl<'a> Wasm<'a> {
+    pub(crate) fn new(var: &'a GoIdentifier, data: WasmData<'a>) -> Self {
+        Self { var, data }
+    }
+}
+
+impl FormatInto<Go> for Wasm<'_> {
+    fn format_into(self, tokens: &mut Tokens<Go>) {
+        match self.data {
+            WasmData::Inline(bytes) => {
+                let hex_rows = bytes
+                    .chunks(16)
+                    .map(|bytes| {
+                        quote! {
+                            $(for b in bytes join ( ) => $(format!("0x{b:02x},")))
+                        }
+                    })
+                    .collect::<Vec<Tokens<Go>>>();
+
+                // TODO(#16): Don't use the internal bindings.out field
+                quote_in! { *tokens =>
+                    var $(self.var) = []byte{
+                        $(for row in hex_rows join ($['\r']) => $row)
+                    }
+                };
+            }
+            WasmData::Embedded(name) => {
+                // TODO(#16): Don't use the internal bindings.out field
+                quote_in! { *tokens =>
+                    import _ "embed"
+
+                    $(embed(name))
+                    var $(self.var) []byte
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use genco::{prelude::*, tokens::Tokens};
+
+    use crate::{
+        codegen::wasm::{Wasm, WasmData},
+        go::GoIdentifier,
+    };
+
+    #[test]
+    fn test_inline_wasm() {
+        let var = GoIdentifier::private("wasm");
+        let wasm = WasmData::Inline(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+        let mut tokens = Tokens::<Go>::new();
+        Wasm::new(&var, wasm).format_into(&mut tokens);
+        assert_eq!(
+            tokens.to_string().unwrap(),
+            r#"var wasm = []byte{
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+}"#
+        );
+    }
+
+    #[test]
+    fn test_embedded_wasm() {
+        let var = GoIdentifier::private("wasm");
+        let wasm = WasmData::Embedded("hello.wasm");
+        let mut tokens = Tokens::<Go>::new();
+        Wasm::new(&var, wasm).format_into(&mut tokens);
+        assert_eq!(
+            tokens.to_string().unwrap(),
+            "import _ \"embed\"\n\n//go:embed hello.wasm\nvar wasm []byte"
+        );
+    }
+}

--- a/cmd/gravity/src/go/identifier.rs
+++ b/cmd/gravity/src/go/identifier.rs
@@ -8,30 +8,39 @@ use genco::{prelude::*, tokens::ItemStr};
 /// - Public identifiers start with uppercase (exported)
 /// - Private identifiers start with lowercase (unexported)
 /// - Local identifiers are used as-is without transformation
-#[derive(Debug, Clone, Copy)]
-pub enum GoIdentifier<'a> {
+#[derive(Debug, Clone)]
+pub enum GoIdentifier {
     /// Public/exported identifier (will be converted to UpperCamelCase)
-    Public { name: &'a str },
+    Public { name: String },
     /// Private/unexported identifier (will be converted to lowerCamelCase)
-    Private { name: &'a str },
+    Private { name: String },
     /// Local identifier (will be converted to lowerCamelCase)
-    Local { name: &'a str },
+    Local { name: String },
 }
 
-impl<'a> GoIdentifier<'a> {
+impl GoIdentifier {
     /// Creates a new public identifier.
-    pub fn public(name: &'a str) -> Self {
-        Self::Public { name }
+    pub fn public<T>(name: T) -> Self
+    where
+        T: Into<String>,
+    {
+        Self::Public { name: name.into() }
     }
 
     /// Creates a new private identifier.
-    pub fn private(name: &'a str) -> Self {
-        Self::Private { name }
+    pub fn private<T>(name: T) -> Self
+    where
+        T: Into<String>,
+    {
+        Self::Private { name: name.into() }
     }
 
     /// Creates a new local identifier.
-    pub fn local(name: &'a str) -> Self {
-        Self::Local { name }
+    pub fn local<T>(name: T) -> Self
+    where
+        T: Into<String>,
+    {
+        Self::Local { name: name.into() }
     }
 
     /// Returns an iterator over the characters of the underlying name.
@@ -40,7 +49,7 @@ impl<'a> GoIdentifier<'a> {
     ///
     /// # Returns
     /// An iterator over the characters of the identifier's name.
-    pub fn chars(&self) -> Chars<'a> {
+    pub fn chars(&self) -> Chars<'_> {
         match self {
             GoIdentifier::Public { name } => name.chars(),
             GoIdentifier::Private { name } => name.chars(),
@@ -49,15 +58,21 @@ impl<'a> GoIdentifier<'a> {
     }
 }
 
-impl From<GoIdentifier<'_>> for String {
+impl From<GoIdentifier> for String {
     fn from(value: GoIdentifier) -> Self {
+        (&value).into()
+    }
+}
+
+impl From<&GoIdentifier> for String {
+    fn from(value: &GoIdentifier) -> Self {
         let mut tokens: Tokens<Go> = Tokens::new();
         value.format_into(&mut tokens);
         tokens.to_string().expect("to format correctly")
     }
 }
 
-impl FormatInto<Go> for &GoIdentifier<'_> {
+impl FormatInto<Go> for &GoIdentifier {
     fn format_into(self, tokens: &mut Tokens<Go>) {
         let mut chars = self.chars();
 
@@ -83,7 +98,7 @@ impl FormatInto<Go> for &GoIdentifier<'_> {
         }
     }
 }
-impl FormatInto<Go> for GoIdentifier<'_> {
+impl FormatInto<Go> for GoIdentifier {
     fn format_into(self, tokens: &mut Tokens<Go>) {
         (&self).format_into(tokens)
     }

--- a/cmd/gravity/src/lib.rs
+++ b/cmd/gravity/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod codegen;
 pub mod go;
 
 use crate::go::GoType;


### PR DESCRIPTION
This starts the refactoring of codegen parts into the library, where it can be tested and more easily changed.

It moves the `Bindings` struct into the library, and adds a new `Wasm` struct responsible for generating code to embed or inline the WebAssembly file.

As part of this, I needed `GoIdentifier` to be an owned type, so I changed it to hold strings instead of references. This doesn't really affect performance because we were always passing references to the output of `format!()` which would allocate a new string anyway.