### PR TITLE
fix: handle new map Instruction variants in wit-bindgen-core 0.56 (supersedes #190)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
+name = "macro-string"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.245.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
+checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
 dependencies = [
  "leb128fmt",
  "wasmparser",
@@ -612,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.245.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da55e60097e8b37b475a0fa35c3420dd71d9eb7bd66109978ab55faf56a57efb"
+checksum = "e3e4c2aa916c425dcca61a6887d3e135acdee2c6d0ed51fd61c08d41ddaf62b1"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -624,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.245.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
+checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
 dependencies = [
  "bitflags",
  "hashbrown",
@@ -733,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.53.1"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e915216dde3e818093168df8380a64fba25df468d626c80dd5d6a184c87e7c7"
+checksum = "7607d30e7e5e8fd5a0695f7cb8b2128829e0bf9dca7a1fe8c4d6ed3ca1058fce"
 dependencies = [
  "bitflags",
  "wit-bindgen-rust-macro",
@@ -743,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.53.1"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deda4b7e9f522d994906f6e6e0fc67965ea8660306940a776b76732be8f3933"
+checksum = "fda3a4ce47c08d27f575d451a60102bab5251776abd0a7a323d1f038eb6339ab"
 dependencies = [
  "anyhow",
  "heck",
@@ -754,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.53.1"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "863a7ab3c4dfee58db196811caeb0718b88412a0aef3d1c2b02fcbae1e37c688"
+checksum = "920a1c8c0f89397431db4900a7bf7c511b78e1b7068289fe812dc76e993f1491"
 dependencies = [
  "anyhow",
  "heck",
@@ -770,11 +781,12 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.53.1"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14f3a9bfa3804bb0e9ab7f66da047f210eded6a1297ae3ba5805b384d64797f"
+checksum = "857a143d2373abfcd31ad946393efe775ed8c90a2a365ce73c61bf38f36a1000"
 dependencies = [
  "anyhow",
+ "macro-string",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -785,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.245.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4894f10d2d5cbc17c77e91f86a1e48e191a788da4425293b55c98b44ba3fcac9"
+checksum = "1936c26cb24b93dc36bf78fb5dc35c55cd37f66ecdc2d2663a717d9fb3ee951e"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -804,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.245.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330698718e82983499419494dd1e3d7811a457a9bf9f69734e8c5f07a2547929"
+checksum = "fd979042b5ff288607ccf3b314145435453f20fc67173195f91062d2289b204d"
 dependencies = [
  "anyhow",
  "hashbrown",

--- a/cmd/gravity/Cargo.toml
+++ b/cmd/gravity/Cargo.toml
@@ -27,8 +27,8 @@ test = false
 [dependencies]
 clap = "=4.6.1"
 genco = "=0.19.0"
-wit-bindgen-core = "=0.53.1"
-wit-component = "=0.245.1"
+wit-bindgen-core = "=0.56.0"
+wit-component = "=0.246.2"
 
 [dev-dependencies]
 # Cutting out `filesystem` feature
@@ -36,4 +36,4 @@ trycmd = { version = "=1.2.0", default-features = false, features = [
   "color-auto",
   "diff",
 ] }
-wit-bindgen = "=0.53.1"
+wit-bindgen = "=0.56.0"

--- a/cmd/gravity/src/codegen/func.rs
+++ b/cmd/gravity/src/codegen/func.rs
@@ -1410,8 +1410,15 @@ impl Bindgen for Func<'_> {
             Instruction::GuestDeallocateString
             | Instruction::GuestDeallocate { .. }
             | Instruction::GuestDeallocateList { .. }
+            | Instruction::GuestDeallocateMap { .. }
             | Instruction::GuestDeallocateVariant { .. } => {
                 unimplemented!("gravity doesn't generate the Guest code")
+            }
+            Instruction::MapLower { .. }
+            | Instruction::MapLift { .. }
+            | Instruction::IterMapKey { .. }
+            | Instruction::IterMapValue { .. } => {
+                todo!("implement instruction: {inst:?}")
             }
             Instruction::FutureLower { .. } => todo!("implement instruction: {inst:?}"),
             Instruction::FutureLift { .. } => todo!("implement instruction: {inst:?}"),

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-wit-bindgen = "=0.53.1"
-wit-component = "=0.245.1"
+wit-bindgen = "=0.56.0"
+wit-component = "=0.246.2"

--- a/examples/iface-method-returns-string/Cargo.toml
+++ b/examples/iface-method-returns-string/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-wit-bindgen = "0.53.1"
-wit-component = "0.245.1"
+wit-bindgen = "0.56.0"
+wit-component = "0.246.2"

--- a/examples/instructions/Cargo.toml
+++ b/examples/instructions/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-wit-bindgen = "=0.53.1"
-wit-component = "=0.245.1"
+wit-bindgen = "=0.56.0"
+wit-component = "=0.246.2"

--- a/examples/records/Cargo.toml
+++ b/examples/records/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-wit-bindgen = "=0.53.1"
-wit-component = "=0.245.1"
+wit-bindgen = "=0.56.0"
+wit-component = "=0.246.2"

--- a/examples/regressions/Cargo.toml
+++ b/examples/regressions/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-wit-bindgen = "=0.53.1"
-wit-component = "=0.245.1"
+wit-bindgen = "=0.56.0"
+wit-component = "=0.246.2"


### PR DESCRIPTION
## Summary

Supersedes #190. This branch contains the same wit group bump (wit-bindgen-core 0.53.1 → 0.56.0, wit-component 0.245.1 → 0.246.2, wit-bindgen 0.53.1 → 0.56.0) **plus** the codegen changes required to make it compile.

wit-bindgen-core 0.56 adds first-class `map<K,V>` support (bytecodealliance/wit-bindgen#1562, #1583), which introduces five new `Instruction` variants. Gravity's `match inst { ... }` in `cmd/gravity/src/codegen/func.rs` is intentionally non-exhaustive-free (no `_ =>` arm) so upstream additions break the build rather than silently emit wrong Go.

New variants handled:

- `GuestDeallocateMap { .. }` — joined to the existing *"gravity doesn't generate the Guest code"* group alongside `GuestDeallocateList`, etc.
- `MapLower { .. }`, `MapLift { .. }`, `IterMapKey { .. }`, `IterMapValue { .. }` — collapsed into a single `todo!("implement instruction: {inst:?}")` arm. Gravity has no Go map codegen yet; if a WIT world with `map<K,V>` is ever fed in, this panics with a clear variant name (same pattern used for `FutureLower`, `StreamLower`, etc.).

## Test plan

- [x] `cargo build --locked` — clean
- [x] `cargo test --locked` — passes
- [x] Built all example wasm with `cargo build -p example-* --target wasm32-unknown-unknown --release`
- [x] `cargo test --locked --test cli` — all 8 snapshot tests pass (no drift from wit-component 0.246)
- [x] `cd examples && go generate ./... && go test ./...` — all Go e2e tests against wazero pass
- [ ] CI green on this PR

Once this merges, #190 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)